### PR TITLE
"Gemify"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+# Specify your gem's dependencies in code-extractor.gemspec
+gemspec

--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ pushed into a new upstream repository.  Additionally, there will be a "deletion
 branch" named `extract_$name`, which can be used to push a deletion commit to
 the source repository.
 
+## Installation
+
+Just install the gem via rubygems:
+
+```console
+$ gem install code-extractor
+```
+
+Or if you want to do it yourself, the `lib/code_extractor.rb` file is a
+standalone ruby script, so you can just download that and run it with a modern
+ruby version.
+
 ## Usage
 
 ### Configuration
@@ -46,7 +58,21 @@ Create a file named `extractions.yml` with the configuration.  For example:
 
 ### Execution
 
-`ruby code_extractor.rb`
+If you have install this as a gem, you can just run:
+
+```console
+$ code-extractor
+```
+
+But if you installed this manually, just either make the script executable, or
+run it with the ruby interpreter via.
+
+```console
+$ ruby code_extractor.rb
+```
+
+This shouldn't be run in the directory of the original repository, but instead
+in an empty directory where the clone can be created and modified.
 
 ### Post-execution
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,31 @@
+# ----------------------------------------------- #
+#                      Build                      #
+# ----------------------------------------------- #
+
 require "rubygems/package_task"
 
 code_extractor_gemspec = eval File.read("code-extractor.gemspec")
 
 Gem::PackageTask.new(code_extractor_gemspec).define
+
+
+# ----------------------------------------------- #
+#                      Test                       #
+# ----------------------------------------------- #
+
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.test_files = FileList["test/**/*_test.rb"]
+end
+
+namespace :test do
+  desc "clean test sandbox"
+  task :clean do
+    sandbox_dir = File.join "test", "tmp"
+    rm_rf sandbox_dir
+  end
+end
+
+task :default => :test

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,5 @@
+require "rubygems/package_task"
+
+code_extractor_gemspec = eval File.read("code-extractor.gemspec")
+
+Gem::PackageTask.new(code_extractor_gemspec).define

--- a/bin/code-extractor
+++ b/bin/code-extractor
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join("..", "..", "lib", "code_extractor"), __FILE__)
+
+CodeExtractor.run

--- a/code-extractor.gemspec
+++ b/code-extractor.gemspec
@@ -24,5 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = ["code-extractor"]
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rake",     "~> 10.0"
+  spec.add_development_dependency "rugged",   "~> 0.28"
 end

--- a/code-extractor.gemspec
+++ b/code-extractor.gemspec
@@ -1,0 +1,26 @@
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "code_extractor/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "code-extractor"
+  spec.version       = CodeExtractor::VERSION
+  spec.authors       = ["Julian Cheal"]
+
+  spec.summary       = "Extracts code from from one repository to another preserving history"
+  spec.description   = "Extracts code from from one repository to another preserving history"
+  spec.homepage      = "https://github.com/juliancheal/code-extractor"
+  spec.license       = "MIT"
+
+  spec.files         = %w[
+    bin/code-extractor
+    lib/code_extractor.rb
+    lib/code_extractor/version.rb
+    code-extractor.gemspec
+    LICENSE
+    README.md
+  ]
+  spec.bindir        = "bin"
+  spec.executables   = ["code-extractor"]
+  spec.require_paths = ["lib"]
+end

--- a/code-extractor.gemspec
+++ b/code-extractor.gemspec
@@ -23,4 +23,6 @@ Gem::Specification.new do |spec|
   spec.bindir        = "bin"
   spec.executables   = ["code-extractor"]
   spec.require_paths = ["lib"]
+
+  spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/lib/code_extractor.rb
+++ b/lib/code_extractor.rb
@@ -5,6 +5,10 @@ require 'yaml'
 class CodeExtractor
   attr_reader :extraction
 
+  def self.run
+    new.extract
+  end
+
   def initialize(extraction = 'extractions.yml')
     @extraction = YAML.load_file(extraction)
     @extraction[:upstream_branch] ||= "master"
@@ -72,6 +76,6 @@ class CodeExtractor
   end
 end
 
-code_extractor = CodeExtractor.new
-
-code_extractor.extract
+if $PROGRAM_NAME == __FILE__
+  CodeExtractor.run
+end

--- a/lib/code_extractor/version.rb
+++ b/lib/code_extractor/version.rb
@@ -1,0 +1,3 @@
+module CodeExtractor
+  VERSION = "0.1.0"
+end

--- a/test/code_extractor_test.rb
+++ b/test/code_extractor_test.rb
@@ -1,0 +1,114 @@
+require 'test_helper'
+
+class CodeExtractorTest < CodeExtractor::TestCase
+  def test_code_extractor
+    repo_structure = %w[
+      foo/bar
+      baz
+    ]
+
+    create_repo repo_structure do
+      update_file "foo/bar", "Bar Content"
+      commit "add Bar content"
+      tag "v1.0"
+
+      add_file "qux", "QUX!!!"
+      commit
+      tag "v2.0"
+    end
+
+    set_extractions ["foo"]
+    output, _ = run_extraction
+
+    assert_no_tags
+    assert output.include? "Cloning…"
+    assert output.include? "Removing tag v1.0"
+    assert output.include? "Removing tag v2.0"
+    assert output.include? 'Extracting Branch…'
+
+    in_git_dir do
+      assert_includes current_commit_message, "Extract my_extractions"
+
+      refute Dir.exist?  "foo"
+      assert File.exist? "baz"
+      assert File.exist? "qux"
+    end
+
+    on_branch "master" do
+      assert_includes current_commit_message, "add Bar content"
+      assert_includes current_commit_message, "(transferred from MyOrg/repo@"
+
+      assert File.exist? "foo/bar"
+      refute File.exist? "baz"
+      refute File.exist? "qux"
+    end
+  end
+
+  def test_code_extractor_removes_existing_extraction_branch
+    repo_structure = %w[
+      foo/bar
+      baz
+    ]
+
+    create_repo repo_structure do
+      create_branch "extract_my_extractions"
+      checkout "extract_my_extractions"
+    end
+
+    set_extractions ["foo"]
+    _, err = run_extraction
+
+    assert_no_tags
+    refute err.include? "fatal: A branch named 'extract_my_extractions' already exists."
+
+    in_git_dir do
+      assert_includes current_commit_message, "Extract my_extractions"
+
+      refute Dir.exist?  "foo"
+      assert File.exist? "baz"
+    end
+
+    on_branch "master" do
+      assert_includes current_commit_message, "Initial Commit"
+      assert_includes current_commit_message, "(transferred from MyOrg/repo@"
+
+      assert File.exist? "foo/bar"
+      refute File.exist? "baz"
+    end
+  end
+
+  def test_code_extractor_skips_cloning_if_directory_exists
+    repo_structure = %w[
+      foo/bar
+      baz
+    ]
+
+    create_repo repo_structure do
+      create_branch "extract_my_extractions"
+      checkout "extract_my_extractions"
+    end
+
+    Rugged::Repository.clone_at repo_dir, extracted_dir
+
+    set_extractions ["foo"]
+    output, _ = run_extraction
+
+    assert_no_tags
+    refute output.include? "Cloning…"
+
+    in_git_dir do
+      assert_includes current_commit_message, "Extract my_extractions"
+
+      refute Dir.exist?  "foo"
+      assert File.exist? "baz"
+    end
+
+    on_branch "master" do
+      assert_includes current_commit_message, "Initial Commit"
+      assert_includes current_commit_message, "(transferred from MyOrg/repo@"
+
+      assert File.exist? "foo/bar"
+      refute File.exist? "baz"
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,287 @@
+$LOAD_PATH.unshift File.expand_path(File.join("..", "..", "lib"), __FILE__)
+
+require 'code_extractor'
+
+require 'yaml'
+require 'fileutils'
+require 'pathname'
+require 'rugged'
+require 'minitest/autorun'
+
+TEST_DIR     = File.expand_path "..", __FILE__
+TEST_SANDBOX = File.join TEST_DIR, "tmp", "sandbox"
+
+FileUtils.mkdir_p TEST_SANDBOX
+
+class CodeExtractor
+  # Base class for all test classes.
+  #
+  # Will create a sandbox directory in `test/tmp/sandbox`, uniq to each test
+  # method, and will initialize the source repo and common settings for every
+  # test, and clean up when it is done.
+  #
+  class TestCase < Minitest::Test
+    attr_writer :extractions, :extractions_hash
+    attr_reader :extracted_dir, :repo_dir, :sandbox_dir
+
+    # Create a sandbox for the given test, and name it after the test class and
+    # method name
+    def setup
+      @extractions   = []
+      @sandbox_dir   = Dir.mktmpdir "#{self.class.name}_#{@NAME}", TEST_SANDBOX
+      @repo_dir      = File.join @sandbox_dir, "repo.git"
+      @extracted_dir = File.join @sandbox_dir, "extracted.git"
+    end
+
+    def teardown
+      FileUtils.remove_entry @sandbox_dir unless ENV["DEBUG"]
+    end
+
+    # Custom Assertions
+
+    def assert_no_tags
+      tags = destination_repo.tags.map(&:name)
+      assert tags.empty?, "Expected there to be no tags, but got `#{tags.join ', '}'"
+    end
+
+    # Helper methods
+
+    def destination_repo
+      @destination_repo ||= Rugged::Repository.new @extracted_dir
+    end
+
+    def current_commit_message
+      destination_repo.head.target.message
+    end
+
+    def in_git_dir
+      Dir.chdir @extracted_dir do
+        yield
+      end
+    end
+
+    def on_branch new_branch, &block
+      current_branch = destination_repo.head.name
+      destination_repo.checkout new_branch
+
+      in_git_dir(&block)
+    ensure
+      destination_repo.checkout current_branch
+    end
+
+    def create_repo file_structure, &block
+      TestRepo.generate repo_dir, file_structure, &block
+    end
+
+    def run_extraction
+      pwd = Dir.pwd
+
+      extractions_yml = File.join sandbox_dir, "extractions.yml"
+      File.write extractions_yml, extractions_yaml
+
+      capture_subprocess_io do
+        CodeExtractor.new(extractions_yml).extract
+      end
+    ensure
+      Dir.chdir pwd
+    end
+
+    def set_extractions new_extractions
+      @extractions = new_extractions
+      extractions_hash[:extractions] = @extractions
+    end
+
+    def extractions_hash
+      @extractions_hash ||= {
+        :name          => "my_extractions",
+        :upstream      => @repo_dir,
+        :upstream_name => "MyOrg/repo",
+        :extractions   => @extractions,
+        :destination   => @extracted_dir
+      }
+    end
+
+    def extractions_yaml
+      extractions_hash.to_yaml
+    end
+  end
+
+  # = TestRepo
+  #
+  # This is a modified form of the fake_ansible_repo.rb spec helper from the
+  # ManageIQ project:
+  #
+  #     https://github.com/ManageIQ/manageiq/blob/f8e70535/spec/support/fake_ansible_repo.rb
+  #
+  # Which uses Rugged to create a stub git project for testing against with a
+  # configurable file structure.  To generate a repo, you just needs to be
+  # given a repo_path and a file tree definition.
+  #
+  #     file_tree_definition = %w[
+  #       foo/one.txt
+  #       bar/baz/two.txt
+  #       qux/
+  #       README.md
+  #     ]
+  #     TestRepo.generate "/path/to/my_repo", file_tree_definition
+  #
+  #
+  # == File Tree Definition
+  #
+  # The file tree definition (file_struct) is just passed in as a word array for
+  # each file/empty-dir entry for the repo.
+  #
+  # So for a single file repo with a `foo.txt` plain text file, the definition
+  # as an array would be:
+  #
+  #     file_struct = %w[
+  #       foo.txt
+  #     ]
+  #
+  # This will generate a repo with a single file called `foo.txt`.  For a more
+  # complex example:
+  #
+  #     file_struct = %w[
+  #       bin/foo
+  #       lib/foo.rb
+  #       lib/foo/version.rb
+  #       test/test_helper.rb
+  #       test/foo_test.rb
+  #       tmp/
+  #       LICENSE
+  #       README.md
+  #     ]
+  #
+  # NOTE:  directories only need to be defined on their own if they are intended
+  # to be empty, otherwise a defining files in them is enough.
+  #
+  class TestRepo
+    attr_reader :file_struct, :last_commit, :repo_path, :repo, :index
+
+    def self.generate repo_path, file_struct, &block
+      repo = new repo_path, file_struct
+      repo.generate(&block)
+    end
+
+    def initialize repo_path, file_struct
+      @commit_count = 0
+      @repo_path    = Pathname.new repo_path
+      @name         = @repo_path.basename
+      @file_struct  = file_struct
+      @last_commit  = nil
+    end
+
+    def generate &block
+      build_repo(repo_path, file_struct)
+
+      git_init
+      git_commit_initial
+
+      instance_eval(&block) if block_given?
+    end
+
+    # Create a new branch (don't checkout)
+    #
+    #   $ git branch other_branch
+    #
+    def create_branch new_branch_name
+      repo.create_branch new_branch_name
+    end
+
+    def checkout branch
+      repo.checkout branch
+    end
+
+    # Commit with all changes added to the index
+    #
+    #   $ git add . && git commit -am "${msg}"
+    #
+    def commit msg = nil
+      git_add_all
+      @commit_count += 1
+
+      @last_commit = Rugged::Commit.create(
+        repo,
+        :message    => msg || "Commit ##{@commit_count}",
+        :parents    => [@last_commit].compact,
+        :tree       => index.write_tree(repo),
+        :update_ref => "HEAD"
+      )
+    end
+
+    def tag tag_name
+      repo.tags.create tag_name, @last_commit
+    end
+
+    # Add (or update) a file in the repo, and optionally write content to it
+    #
+    # The content is optional, but it will fully overwrite the content
+    # currently in the file.
+    #
+    def add_file entry, content = nil
+      path          = repo_path.join entry
+      dir, filename = path.split unless entry.end_with? "/"
+
+      FileUtils.mkdir_p dir.to_s == '.' ? repo_path : dir
+      FileUtils.touch path     if filename
+      File.write path, content if filename && content
+    end
+    alias update_file add_file
+
+    # Prepends content to an existing file
+    #
+    def add_to_file entry, content
+      path = repo_path.join entry
+      File.write path, content, :mode => "a"
+    end
+
+    private
+
+    # Generate repo structure based on file_structure array
+    #
+    # By providing a directory location and an array of paths to generate,
+    # this will build a repository directory structure.  If a specific entry
+    # ends with a '/', then an empty directory will be generated.
+    #
+    # Example file structure array:
+    #
+    #     file_struct = %w[
+    #       foo/one.txt
+    #       bar/two.txt
+    #       baz/
+    #       qux.txt
+    #     ]
+    #
+    def build_repo repo_path, file_structure
+      file_structure.each do |entry|
+        add_file entry
+      end
+    end
+
+    # Init new repo at local_repo
+    #
+    #   $ cd /tmp/clone_dir/test_repo && git init .
+    #
+    def git_init
+      @repo  = Rugged::Repository.init_at repo_path.to_s
+      @index = repo.index
+    end
+
+    # Add new files to index
+    #
+    #   $ git add .
+    #
+    def git_add_all
+      index.add_all
+      index.write
+    end
+
+    # Create initial commit
+    #
+    #   $ git commit -m "Initial Commit"
+    #
+    def git_commit_initial
+      commit "Initial Commit"
+    end
+  end
+end


### PR DESCRIPTION
Converts this project to be distributable on rubygems.

Doesn't change much, and you can still install this as a standalone script, but provides a easier way to support adding features to the project going forward.


Additions:
----------

- A gemspec
- Dedicated `bin/` file
- Minor modifications to the lib file to support "gemification"
- Gemfile (bundler support, though not required)
- Rake build tasks
- Dev dependencies for specs:
  * `rake`     (included with most rubies)
  * `minitest` (included with most rubies)
  * `rugged`   (required for running tests
- Some simple tests


More info in the specific commits.