### PR TITLE
Convert CodeExtractor to a module

### DIFF
--- a/lib/code_extractor.rb
+++ b/lib/code_extractor.rb
@@ -2,77 +2,80 @@ require 'yaml'
 
 # Class to extract files and folders from a git repository, while maintaining
 # The git history.
-class CodeExtractor
-  attr_reader :extraction
-
-  def self.run
-    new.extract
+module CodeExtractor
+  def run
+    Runner.new.extract
   end
+  module_function :run
 
-  def initialize(extraction = 'extractions.yml')
-    @extraction = YAML.load_file(extraction)
-    @extraction[:upstream_branch] ||= "master"
+  class Runner
+    attr_reader :extraction
 
-    missing = %i[name destination upstream upstream_name extractions].reject { |k| @extraction[k] }
-    raise ArgumentError, "#{missing.map(&:inspect).join(", ")} key(s) missing" if missing.any?
+    def initialize(extraction = 'extractions.yml')
+      @extraction = YAML.load_file(extraction)
+      @extraction[:upstream_branch] ||= "master"
 
-    @extraction[:destination] = File.expand_path(@extraction[:destination])
-  end
+      missing = %i[name destination upstream upstream_name extractions].reject { |k| @extraction[k] }
+      raise ArgumentError, "#{missing.map(&:inspect).join(", ")} key(s) missing" if missing.any?
 
-  def extract
-    puts @extraction
-    clone
-    extract_branch
-    remove_remote
-    remove_tags
-    filter_branch
-  end
-
-  def clone
-    return if Dir.exist?(@extraction[:destination])
-    puts 'Cloning…'
-    system "git clone -o upstream #{@extraction[:upstream]} #{@extraction[:destination]}"
-  end
-
-  def extract_branch
-    puts 'Extracting Branch…'
-    Dir.chdir(@extraction[:destination])
-    branch = "extract_#{@extraction[:name]}"
-    `git checkout #{@extraction[:upstream_branch]}`
-    `git fetch upstream && git rebase upstream/master`
-    if system("git branch | grep #{branch}")
-      `git branch -D #{branch}`
+      @extraction[:destination] = File.expand_path(@extraction[:destination])
     end
-    `git checkout -b #{branch}`
-    extractions = @extraction[:extractions].join(' ')
-    `git rm -r #{extractions}`
-    `git commit -m "Extract #{@extraction[:name]}"`
-  end
 
-  def remove_remote
-    `git remote rm upstream`
-  end
-
-  def remove_tags
-    puts 'removing tags'
-    tags = `git tag`
-    tags.split.each do |tag|
-      puts "Removing tag #{tag}"
-      `git tag -d #{tag}`
+    def extract
+      puts @extraction
+      clone
+      extract_branch
+      remove_remote
+      remove_tags
+      filter_branch
     end
-  end
 
-  def filter_branch
-    extractions = @extraction[:extractions].join(' ')
-    `time git filter-branch --index-filter '
-    git read-tree --empty
-    git reset $GIT_COMMIT -- #{extractions}
-    ' --msg-filter '
-    cat -
-    echo
-    echo
-    echo "(transferred from #{@extraction[:upstream_name]}@$GIT_COMMIT)"
-    ' -- #{@extraction[:upstream_branch]} -- #{extractions}`
+    def clone
+      return if Dir.exist?(@extraction[:destination])
+      puts 'Cloning…'
+      system "git clone -o upstream #{@extraction[:upstream]} #{@extraction[:destination]}"
+    end
+
+    def extract_branch
+      puts 'Extracting Branch…'
+      Dir.chdir(@extraction[:destination])
+      branch = "extract_#{@extraction[:name]}"
+      `git checkout #{@extraction[:upstream_branch]}`
+      `git fetch upstream && git rebase upstream/master`
+      if system("git branch | grep #{branch}")
+        `git branch -D #{branch}`
+      end
+      `git checkout -b #{branch}`
+      extractions = @extraction[:extractions].join(' ')
+      `git rm -r #{extractions}`
+      `git commit -m "Extract #{@extraction[:name]}"`
+    end
+
+    def remove_remote
+      `git remote rm upstream`
+    end
+
+    def remove_tags
+      puts 'removing tags'
+      tags = `git tag`
+      tags.split.each do |tag|
+        puts "Removing tag #{tag}"
+        `git tag -d #{tag}`
+      end
+    end
+
+    def filter_branch
+      extractions = @extraction[:extractions].join(' ')
+      `time git filter-branch --index-filter '
+      git read-tree --empty
+      git reset $GIT_COMMIT -- #{extractions}
+      ' --msg-filter '
+      cat -
+      echo
+      echo
+      echo "(transferred from #{@extraction[:upstream_name]}@$GIT_COMMIT)"
+      ' -- #{@extraction[:upstream_branch]} -- #{extractions}`
+    end
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,7 @@ TEST_SANDBOX = File.join TEST_DIR, "tmp", "sandbox"
 
 FileUtils.mkdir_p TEST_SANDBOX
 
-class CodeExtractor
+module CodeExtractor
   # Base class for all test classes.
   #
   # Will create a sandbox directory in `test/tmp/sandbox`, uniq to each test
@@ -80,7 +80,7 @@ class CodeExtractor
       File.write extractions_yml, extractions_yaml
 
       capture_subprocess_io do
-        CodeExtractor.new(extractions_yml).extract
+        CodeExtractor::Runner.new(extractions_yml).extract
       end
     ensure
       Dir.chdir pwd

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -80,7 +80,8 @@ module CodeExtractor
       File.write extractions_yml, extractions_yaml
 
       capture_subprocess_io do
-        CodeExtractor::Runner.new(extractions_yml).extract
+        config = Config.new extractions_yml
+        Runner.new(config).extract
       end
     ensure
       Dir.chdir pwd


### PR DESCRIPTION
Built off of #9 currently

This could have been done as part of the "Gemify" effort, but the intent of that branch was to make as few changes to the core script before starting to make sweeping changes.

By converting `CodeExtractor` to a `module`, that file and `lib/code_extractor/version.rb` can be loaded at the same time (yes, they couldn't before...), and it is just a better practice for dealing with namespaces in general.

The `Runner` class was a necessary side effect, but I think it is mostly understandable what it's role is and should be a straight forward change.


Fun Fact
--------

The `attr_reader :extraction` is actually never used.  Kept it as a part of `CodeExtractor::Runner`, but really, it is never used.